### PR TITLE
nut.c: add support for ups.realpower

### DIFF
--- a/src/nut.c
+++ b/src/nut.c
@@ -326,6 +326,8 @@ static int nut_read(user_data_t *user_data) {
         nut_submit(ups, "percent", "load", value);
       else if (strcmp("ups.power", key) == 0)
         nut_submit(ups, "power", "ups", value);
+      else if (strcmp("ups.realpower", key) == 0)
+        nut_submit(ups, "power", "watt-ups", value);
       else if (strcmp("ups.temperature", key) == 0)
         nut_submit(ups, "temperature", "ups", value);
     }


### PR DESCRIPTION
Some UPS report a global "realpower" value corresponding to actual Watts
instead of VA as part of the "ups." key.
The Eaton Ellipse series is such an example: where the device does not
report current values but only voltages, watts and VA.
This commit makes that value available in reported statistics using the
"watt-ups" type_instance, matching 64321ae